### PR TITLE
allow RecipesBase to bump up 1.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ ColorTypes = "^0"
 FastGaussQuadrature = "^0"
 NLsolve = "^4"
 OrdinaryDiffEq = "^5"
-RecipesBase = "^0"
+RecipesBase = "< 2"
 Reexport = "^0"
 
 [extras]


### PR DESCRIPTION
A major version of RecipesBase.jl has been released.
See  https://github.com/JuliaPlots/RecipesBase.jl/tags

This pull request allows this package to use the major version of the RecipesBase.jl as a dependent package.

